### PR TITLE
Check for the bootloader switch first thing in main() in case normal …

### DIFF
--- a/Source code/Embedded/src/Boot.c
+++ b/Source code/Embedded/src/Boot.c
@@ -5,12 +5,47 @@
  *  Author: Sensics
  */
 
+#include "GlobalOptions.h"
+#include "my_hardware.h"
+#include <ioport.h>
 #include <udc.h>
 
 #include "Boot.h"
+#include <stdint.h>
+#include <avr/io.h>
+
+#define ISP_PORT_DIR PORTE_DIR
+#define ISP_PORT_PINCTRL PORTE_PIN5CTRL
+#define ISP_PORT_IN PORTE_IN
+#define ISP_PORT_PIN 5
+
+void CheckForBootloaderSwitchOnStartup()
+{
+	// read the pin:
+	// brute force the whole thing as input
+	ISP_PORT_DIR = 0x0;
+	// enable pull-up
+	ISP_PORT_PINCTRL = 0x18;
+	// delay equiv. to in the assembly
+	for (uint8_t n = 0xff; n; --n)
+	{
+		barrier();
+	}
+
+	// If pin is low, start the bootloader.
+	if (!(ISP_PORT_IN & _BV(ISP_PORT_PIN)))
+	{
+#ifdef Debug_LED
+		// Turn the LED on to indicate that we didn't get into the bootloader the normal way.
+		ioport_set_pin_dir(Debug_LED, IOPORT_DIR_OUTPUT);
+		Debug_LED_Turn_On();
+#endif
+		PrepareForSoftwareUpgrade();
+	}
+	ISP_PORT_PINCTRL = 0x0;
+}
 
 void PrepareForSoftwareUpgrade(void)
-
 {
 	// code is taken from here: http://www.avrfreaks.net/index.php?name=PNphpBB2&file=printview&t=125724&start=0
 

--- a/Source code/Embedded/src/Boot.h
+++ b/Source code/Embedded/src/Boot.h
@@ -8,6 +8,7 @@
 #ifndef BOOT_H_
 #define BOOT_H_
 
+void CheckForBootloaderSwitchOnStartup(void);
 void PrepareForSoftwareUpgrade(void);
 
 #endif /* BOOT_H_ */

--- a/Source code/Embedded/src/main.c
+++ b/Source code/Embedded/src/main.c
@@ -42,6 +42,7 @@
  */
 
 #include "main.h"
+#include "Boot.h"
 
 #include <asf.h>
 #include <pmic.h>
@@ -83,6 +84,12 @@ void load_configuration(void)
 int main(void)
 {
 	//_StackPaint();
+
+	// In case the bootloader that's on board isn't working right or the board
+	// isn't working right, give the switch a bit of a chance to be read.
+	// Should be unnecessary, but extant hardware is reluctant to respond to
+	// the bootloader switch.
+	CheckForBootloaderSwitchOnStartup();
 
 	irq_initialize_vectors();
 


### PR DESCRIPTION
…init missed it.

Future-proofing against semi-bricking that requires an ICE. For some reason, devices in the field don't seem to obey the bootloader switch all the time. This gives them a second chance to do so.

Some code added is functionally equivalent to portions of the Atmel DFU
bootloader assembly, but written in C instead. (Portable, don't have to fit
in a small bootloader segment, etc)