### PR TITLE
BNO070: Load whether we're in RV or GRV from correct eeprom location.

### DIFF
--- a/Source code/Embedded/src/DeviceDrivers/BNO070_using_hostif.c
+++ b/Source code/Embedded/src/DeviceDrivers/BNO070_using_hostif.c
@@ -467,7 +467,7 @@ bool init_BNO070(void)
 	int result;
 
 	// determine if we are in GRV or RV mode
-	GetValidConfigValueOrWriteDefault(SideBySideOffset, BNO_USE_GRV, &SELECT_GRV);
+	GetValidConfigValueOrWriteDefault(GRVOffset, BNO_USE_GRV, &SELECT_GRV);
 
 	// Clear BNO070_Report so we don't send garbage out the USB.
 	memset(BNO070_Report, 0, sizeof(BNO070_Report));


### PR DESCRIPTION
This should fix a copy-paste bug introduced in 1.95