### PR TITLE
Adjust makefile: dSight is xmega256a3u, not 256a3bu.

### DIFF
--- a/Source code/Embedded/makefile-build/Makefile
+++ b/Source code/Embedded/makefile-build/Makefile
@@ -56,10 +56,6 @@ OUTPUT_LSS := $(OUTPUT_STEM).lss
 # Relative path from makefile to source root
 REL_ROOT := ..
 
-MCU:=atxmega256a3bu
-# Used for compilation databases, for code analysis tools
-MIXED_CASE_MCU:=ATxmega256A3BU
-
 C_SRCS :=  \
 src/Boot.c \
 src/Console.c \
@@ -178,9 +174,9 @@ BASE_DEFINES := CONFIG_NVM_IGNORE_XMEGA_A3_D3_REVB_ERRATA \
 
 ALL_DEFINES := $(BASE_DEFINES) $(DEFINES)
 
-COMMON_FLAGS := -mmcu=$(MCU) -mrelax $(patsubst %, -D%,$(ALL_DEFINES))
+COMMON_FLAGS = -mmcu=$(MCU) -mrelax $(patsubst %, -D%,$(ALL_DEFINES))
 
-BASE_LDFLAGS := $(COMMON_FLAGS) -Wl,--relax -Wl,--gc-sections
+BASE_LDFLAGS = $(COMMON_FLAGS) -Wl,--relax -Wl,--gc-sections
 
 #LDFLAGS := -Wl,--section-start=.BOOT=0x40000
 
@@ -189,13 +185,13 @@ BASE_LDFLAGS := $(COMMON_FLAGS) -Wl,--relax -Wl,--gc-sections
 # bootloader.
 LDFLAGS :=
 
-ALL_LDFLAGS := $(BASE_LDFLAGS) $(LDFLAGS)
+ALL_LDFLAGS = $(BASE_LDFLAGS) $(LDFLAGS)
 
 ALL_CFLAGS = $(COMMON_FLAGS) -c -std=gnu99 \
               -ffunction-sections -fdata-sections \
               -fpack-struct -fshort-enums -fno-strict-aliasing \
               $(CFLAGS) $(EXTRA_CFLAGS)
-ALL_ASFLAGS := -Wa,-gdwarf2 -x assembler-with-cpp -c $(COMMON_FLAGS) $(ASFLAGS) $(EXTRA_ASFLAGS)
+ALL_ASFLAGS = -Wa,-gdwarf2 -x assembler-with-cpp -c $(COMMON_FLAGS) $(ASFLAGS) $(EXTRA_ASFLAGS)
 
 ifeq (,$(strip $(DEFINES)))
     # no separator if no special defines
@@ -280,6 +276,10 @@ CONFIG_REALCLEAN_TARGET = $(CONFIG)_realclean
 ###
 # The Variants
 ###
+MCU:=atxmega256a3bu
+# Used for compilation databases, for code analysis tools
+MIXED_CASE_MCU:=ATxmega256A3BU
+
 SHORT_NAME := hdk2
 VARIANT_NAME := HDK_20
 include add_variant.mk
@@ -298,6 +298,8 @@ include add_variant.mk
 
 SHORT_NAME := dsight
 VARIANT_NAME := dSight_Sharp_LCD
+MCU:=atxmega256a3u
+MIXED_CASE_MCU:=ATxmega256A3U
 include add_variant.mk
 
 # Done with variants.

--- a/Source code/Embedded/makefile-build/add_variant.mk
+++ b/Source code/Embedded/makefile-build/add_variant.mk
@@ -68,6 +68,7 @@ $(BUILD_DIR)/%.i: $(REL_ROOT)/%.c
 	$(CANNED_RECIPE_BEGINNING_SHOW_IN_AND_OUT)
 	$(QUIETRULE)$(CC) $(call make_include_dirs,$(VARIANT)) $(ALL_CFLAGS) -w -E -dDI -C -o "$@" "$<"
 
+
 # For all non-ASF files, make a shortcut phony target that's just $(BUILD_DIR)/basename.i to keep the typing shorter.
 define make_preprocess_phony_target
 # only if this would actually be a shortcut and not just replace the real target
@@ -99,7 +100,7 @@ json_stringify = jq -R "." >>"$@"
 # These complement SYSTEM_FLAGS (which typically is something like -isystem path/to/your/avr/includes)
 # by including notable things from avr-gcc -mmcu=$(MCU) -dM -E dummy.c output
 
-WELL_KNOWN_SYSTEM_FLAGS = -DAVR -D__AVR=1 -D__AVR__=1 -D__WITH_AVRLIBC__=1 -D__AVR_DEVICE_NAME__=$(MCU) -D__AVR_$(MIXED_CASE_MCU)__=1
+WELL_KNOWN_SYSTEM_FLAGS := -DAVR -D__AVR=1 -D__AVR__=1 -D__WITH_AVRLIBC__=1 -D__AVR_DEVICE_NAME__=$(MCU) -D__AVR_$(MIXED_CASE_MCU)__=1
 
 ARCH5_FLAGS := -D__AVR_ENHANCED__=1 \
                -D__AVR_HAVE_JMP_CALL__=1 \
@@ -129,10 +130,13 @@ endif
 ifeq ($(strip $(MCU)),atxmega256a3bu)
 WELL_KNOWN_SYSTEM_FLAGS += -D__AVR_ARCH__=106 $(ARCH106_FLAGS) -D__AVR_3_BYTE_PC__=1
 else
+ifeq ($(strip $(MCU)),atxmega256a3u)
+WELL_KNOWN_SYSTEM_FLAGS += -D__AVR_ARCH__=106 $(ARCH106_FLAGS) -D__AVR_3_BYTE_PC__=1
+else
 WELL_KNOWN_SYSTEM_FLAGS += $(DEFAULT_ARCH_SYSTEM_FLAGS)
 $(warning Do not know the pre-defined constants for that MCU, sorry! your compiledb $(COMPILATION_DATABASE_FILENAME) might be insufficient!)
 endif
-
+endif
 
 # the PARAMS get sucked in as a string array: lines as follows:
 # the main part of the compile command (some must be manually kept in sync!)
@@ -185,6 +189,7 @@ include add_config.mk
 # set target-specific variables - have to do this here, where these are not recursively defined.
 $(BUILD_DIR)/%: SUFFIX := $(SUFFIX)
 $(BUILD_DIR)/%: VARIANT := $(VARIANT)
+$(BUILD_DIR)/%: MCU := $(MCU)
 
 # Clean up work variables
 C_OBJS :=


### PR DESCRIPTION
The dSight uses a different (though very similar) MCU - atxmega256*a3u* instead of atxmega256*a3bu* like the HDKs. Atmel Studio doesn't deal well with this idea, but fortunately Makefiles can, and with this PR, they do.

Can verify by running

```sh
make dsight VERBOSE=1
# observe flag being passed to compiler is -mcu=atxmega256a3u

make hdk_oled VERBOSE=1
# observe flag being passed to compiler is -mcu=atxmega256a3bu
```